### PR TITLE
Move api routes to /api/ path for cleaner separation from the web site

### DIFF
--- a/openods_api/config.py
+++ b/openods_api/config.py
@@ -3,7 +3,7 @@ import os
 TARGET_SCHEMA_VERSION = '007'
 DATABASE_URL = os.environ.get('DATABASE_URL', 'postgresql://openods:openods@localhost:5432/openods')
 CACHE_TIMEOUT = int(os.environ.get('CACHE_TIMEOUT', '30'))
-APP_HOSTNAME = os.environ.get('APP_HOSTNAME', 'localhost:5000')
+APP_HOSTNAME = os.environ.get('APP_HOSTNAME', 'localhost:5000/api')
 API_USER = os.environ.get('API_USER', 'user')
 API_PASS = os.environ.get('API_PASS', 'pass')
 API_USE_AUTH = os.environ.get('API_USE_AUTH', 'FALSE')

--- a/openods_api/routes.py
+++ b/openods_api/routes.py
@@ -45,7 +45,7 @@ def documentation():
 
 
 @auto.doc()
-@app.route("/organisations/", methods=['GET'])
+@app.route("/api/organisations/", methods=['GET'])
 @requires_auth
 @ocache.cache.cached(timeout=config.CACHE_TIMEOUT, key_prefix=ocache.generate_cache_key)
 def get_organisations():
@@ -83,7 +83,7 @@ def get_organisations():
 
 
 @auto.doc()
-@app.route("/organisations/<ods_code>/", methods=['GET'])
+@app.route("/api/organisations/<ods_code>/", methods=['GET'])
 @requires_auth
 @ocache.cache.cached(timeout=config.CACHE_TIMEOUT, key_prefix=ocache.generate_cache_key)
 def get_organisation(ods_code):
@@ -132,7 +132,7 @@ def get_organisation(ods_code):
 
 
 @auto.doc()
-@app.route("/organisations/search/<search_text>/", methods=['GET'])
+@app.route("/api/organisations/search/<search_text>/", methods=['GET'])
 @requires_auth
 @ocache.cache.cached(timeout=config.CACHE_TIMEOUT, key_prefix=ocache.generate_cache_key)
 def search_organisations(search_text):
@@ -162,7 +162,7 @@ def search_organisations(search_text):
 
 
 @auto.doc()
-@app.route("/role-types/", methods=['GET'])
+@app.route("/api/role-types/", methods=['GET'])
 @requires_auth
 @ocache.cache.cached(timeout=config.CACHE_TIMEOUT, key_prefix=ocache.generate_cache_key)
 def route_role_types():
@@ -183,7 +183,7 @@ def route_role_types():
 
 
 @auto.doc()
-@app.route("/role-types/<role_code>/", methods=['GET'])
+@app.route("/api/role-types/<role_code>/", methods=['GET'])
 @requires_auth
 @ocache.cache.cached(timeout=config.CACHE_TIMEOUT, key_prefix=ocache.generate_cache_key)
 def route_role_type_by_code(role_code):
@@ -199,7 +199,7 @@ def route_role_type_by_code(role_code):
 
 
 @auto.doc()
-@app.route("/organisations/<ods_code>/endpoints/", methods=['GET'])
+@app.route("/api/organisations/<ods_code>/endpoints/", methods=['GET'])
 @requires_auth
 @ocache.cache.cached(timeout=config.CACHE_TIMEOUT, key_prefix=ocache.generate_cache_key)
 def organisation_endpoints(ods_code):

--- a/openods_api/templates/tryit.html
+++ b/openods_api/templates/tryit.html
@@ -11,7 +11,7 @@
             Try it now!
         </h1>
         <div class="input-group">
-              <span class="input-group-addon">http://www.openods.co.uk/</span>
+              <span class="input-group-addon">http://www.openods.co.uk/api/</span>
               <input id="interactive" type="text" class="form-control" placeholder="organisations/A/">
               <span class="input-group-btn"><button onClick="interactive_call();return false;" class="btn btn-primary">request</button></span>
             </div>
@@ -38,7 +38,7 @@
         "status": "Active",
         "links": [
           {
-            "href": "http://localhost:5000/role-types/RO128",
+            "href": "http://www.openods.co.uk/api/role-types/RO128",
             "rel": "role-type"
           }
         ],
@@ -48,7 +48,7 @@
   ],
   "links": [
     {
-      "href": "http://localhost:5000/organisations/A",
+      "href": "http://www.openods.co.uk/api/organisations/A",
       "rel": "self"
     }
   ],
@@ -60,7 +60,7 @@
     </div>
 </div>
     <div class="col-sm-2"></div>
-    <div class="col-sm-8">TryIt page borrowed from the awesome <a href="http://swapi.co">Star Wars API www.swapi.co</a></div>
+    <div class="col-sm-8">"Try It" page borrowed from the awesome <a href="http://swapi.co">Star Wars API www.swapi.co</a></div>
 <div class="row"></div>
 {% endblock %}
 
@@ -76,7 +76,7 @@
         if(content == ''){
             content = 'organisations/A/';
         }
-        var call_url = '/' + content;
+        var call_url = '/api/' + content;
         jQuery.ajax({
       dataType: 'json',
       url: call_url,


### PR DESCRIPTION
I have moved all the API routes so that they are under the path of /api/

e.g. http://www.openods.co.uk/api/organisations/

This will allow us to more cleanly separate from the main site at the room (i.e. www.openods.co.uk)

@tonyyates quick review appreciated